### PR TITLE
MAVEN_SNAPSHOT env is now set globally in release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+env:
+  MAVEN_SNAPSHOT: false
+
 jobs:
   publish:
     name: Publish release build
@@ -30,8 +33,6 @@ jobs:
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
-        env:
-          MAVEN_SNAPSHOT: false
 
       - name: Clean up secrets
         if: always()


### PR DESCRIPTION
### Changes

MAVEN_SNAPSHOT is now set to false globaly in publish-release workflow. Thanks to this it will be applied to all build steps and gradle will print proper version in each one of them.

### Testing


### Checklist

#### General
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [ ] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [ ] Added ktdoc and updated README.md if API has changed
- [ ] Made sure that unit tests pass
- [ ] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [ ] Updated demo app if needed

### Reviewer Checklist
- [ ] Library builds
- [ ] Demo app works
- [ ] Changes work as expected
- [ ] Changelog and documentation updates reflect the modification made in this PR
